### PR TITLE
Fix Eventbrite order title parsing

### DIFF
--- a/risk_salon_tools/services/mailchimp.py
+++ b/risk_salon_tools/services/mailchimp.py
@@ -1,6 +1,7 @@
 # TODO move some of these methods into the community.* namespace
 
 import datetime
+import re
 import pandas as pd
 
 from collections import OrderedDict
@@ -97,7 +98,8 @@ class MailChimpList(MailChimpClient):
 
         def has_product(lines, event_date, event_name):
             for line in lines:
-                line_date, line_name, line_ticket_name = line['product_title'].split(' - ')
+                matches = re.match('^((?:(?!-).)*) - (.*) - (.*)$', line['product_title'])
+                line_date, line_name, line_ticket_name = matches.groups()
                 if line_date == event_date and line_name == event_name:
                     return True
 


### PR DESCRIPTION
### What's changed & why it's useful 
Change from splitting on '-' to a regex to capture date and ticket name as being '-' delimited, and assume everything in between is event name. Useful to support event names containing a '-'.

### Reviewer checklist 
 - [x] No PII or secrets in here

